### PR TITLE
Adding mutation observer injection for WebKitBlocks

### DIFF
--- a/src/main/resources/org/luwrain/web/mutation_observer_injection.js
+++ b/src/main/resources/org/luwrain/web/mutation_observer_injection.js
@@ -1,0 +1,15 @@
+function mutationCallback(mutationsList, observer) {
+    webKitBlocks.setNeedsToBeUpdated(true);
+}
+
+const observer = new MutationObserver(mutationCallback);
+
+const target = document.body
+
+const config = {
+    subtree: true,
+    childList: true,
+    attributes: true
+};
+
+observer.observe(target, config);


### PR DESCRIPTION
Adding mutation_observer_injection.js in web
Inplementing method enableMutationObserver method in class WebKitBlocks for injecting the script
Adding needsToBeUpdated flag and setter and getter on it. 